### PR TITLE
Fix reappearing semantic segmentation after deletion

### DIFF
--- a/frontend/image-tool/src/businessNew/actions/flow.ts
+++ b/frontend/image-tool/src/businessNew/actions/flow.ts
@@ -33,10 +33,16 @@ export const dataFrameLast = defineAction({
     else changeFrame(editor, -1);
   },
 });
-function changeFrame(editor: Editor, step: number) {
+async function changeFrame(editor: Editor, step: number) {
   const { frames, frameIndex } = editor.state;
   const index = frameIndex + step;
   if (index < 0 || index >= frames.length) return;
+  // Auto-save pending changes before switching frames
+  const needSave = frames.findIndex((e) => e.needSave) !== -1;
+  if (needSave) {
+    const result = await editor.save();
+    if (!result) return;
+  }
   editor.switchFrame(index);
 }
 async function changeScene(editor: Editor, step: number) {

--- a/frontend/image-tool/src/businessNew/components/Header/useFlowIndex.ts
+++ b/frontend/image-tool/src/businessNew/components/Header/useFlowIndex.ts
@@ -42,6 +42,12 @@ export default function useFlowIndex() {
       if (index < 0 || index >= frames.length) {
         return;
       }
+      // Persist pending changes before switching frames
+      const needSave = frames.findIndex((e) => e.needSave) !== -1;
+      if (needSave) {
+        const result = await editor.save();
+        if (!result) return;
+      }
       editor.switchFrame(index);
     }
   }

--- a/frontend/image-tool/src/package/image-editor/common/ActionManager/action/seriesFrame.ts
+++ b/frontend/image-tool/src/package/image-editor/common/ActionManager/action/seriesFrame.ts
@@ -35,10 +35,16 @@ export const copyToLast = define({
   },
 });
 
-function changeFrame(editor: Editor, type: number) {
+async function changeFrame(editor: Editor, type: number) {
   const { frames, frameIndex } = editor.state;
   const index = frameIndex + type;
   if (index < 0 || index >= frames.length) return;
+  // Auto-save pending changes before switching frames
+  const needSave = frames.findIndex((e) => e.needSave) !== -1;
+  if (needSave) {
+    const result = await editor.save();
+    if (!result) return;
+  }
   editor.switchFrame(index);
 }
 function canCopy(editor: Editor) {

--- a/frontend/image-tool/yarn.lock
+++ b/frontend/image-tool/yarn.lock
@@ -313,10 +313,10 @@
   resolved "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz"
   integrity sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==
 
-"@esbuild/win32-x64@0.18.20":
+"@esbuild/linux-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz"
-  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz"
+  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.7.0"


### PR DESCRIPTION
Auto-save pending changes before frame navigation to prevent deleted instance semantic segmentations (ISS) from reappearing.

---
<a href="https://cursor.com/background-agent?bcId=bc-342e4a0c-43b3-46af-a967-ae327098e4f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-342e4a0c-43b3-46af-a967-ae327098e4f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

